### PR TITLE
71194 fixsince

### DIFF
--- a/src/Dfe.CdcEventApi.Infrastructure.SqlServer/LoadHandlers/Retrieve_Raw_LoadSince.sql
+++ b/src/Dfe.CdcEventApi.Infrastructure.SqlServer/LoadHandlers/Retrieve_Raw_LoadSince.sql
@@ -8,7 +8,7 @@ SELECT
 FROM
 	[dbo].[Raw_Load]
 WHERE 
-	 [Load_DateTime]  = @RunIdentifier
+	 [Load_DateTime]  BETWEEN DATEADD(ms,-5, @RunIdentifier) AND DATEADD(ms,5, @RunIdentifier)
 UNION
 SELECT 
 	load.[Load_DateTime] AS [Load_DateTime],
@@ -26,7 +26,7 @@ INNER JOIN
 		 FROM
 			[dbo].[Raw_Load] 
 		WHERE 
-			[Load_DateTime] < @RunIdentifier
+			[Load_DateTime] < DATEADD(ms,-5, @RunIdentifier)
 		GROUP BY 
 			[Status]
 		HAVING

--- a/src/Dfe.CdcEventApi.Infrastructure.SqlServer/LoadHandlers/Retrieve_Raw_LoadSince.sql
+++ b/src/Dfe.CdcEventApi.Infrastructure.SqlServer/LoadHandlers/Retrieve_Raw_LoadSince.sql
@@ -8,20 +8,30 @@ SELECT
 FROM
 	[dbo].[Raw_Load]
 WHERE 
-	 [Load_DateTime]  BETWEEN DATEADD(ms,-5, @RunIdentifier) AND DATEADD(ms,5, @RunIdentifier)
+	 [Load_DateTime]  = @RunIdentifier
 UNION
-SELECT TOP 1
-	[Load_DateTime],
-	[Finish_DateTime],
-	[Status],
-	[ReportTitle],
-	[ReportBody],
-	[ReportedTo]
+SELECT 
+	load.[Load_DateTime] AS [Load_DateTime],
+	load.[Finish_DateTime] AS [Finish_DateTime],
+	load.[Status] AS [Status],
+	load.[ReportTitle] AS [ReportTitle],
+	load.[ReportBody] AS [ReportBody],
+	load.[ReportedTo] AS [ReportedTo]
 FROM
-	[dbo].[Raw_Load]
-WHERE 
-	 [Load_DateTime]  < DATEADD(ms,-5, @RunIdentifier)
-AND
-	[Status] = 32
+	[dbo].[Raw_Load] load
+INNER JOIN 
+	 (
+		 SELECT 
+			MAX( [Load_DateTime] ) AS [Load_DateTime], [Status]
+		 FROM
+			[dbo].[Raw_Load] 
+		WHERE 
+			[Load_DateTime] < @RunIdentifier
+		GROUP BY 
+			[Status]
+		HAVING
+			[Status] = 32
+	) latest
+ON load.[Load_DateTime] = latest.[Load_DateTime]
 ORDER BY
 	[Load_DateTime] DESC


### PR DESCRIPTION
The Load Since SQL incorrectly brought back the seed date time instead of the last successful run date time. 
Resulting in complete loads of the database every time.
This SQL change corrects that problem.